### PR TITLE
update TrailingCommaInLiteral style options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -454,7 +454,9 @@ TernaryParentheses:
   Enabled: false
 TrailingCommaInArguments:
   Enabled: false
-TrailingCommaInLiteral:
+TrailingCommaInArrayLiteral:
+  Enabled: false
+TrailingCommaInHashLiteral:
   Enabled: false
 TrailingUnderscoreVariable:
   Enabled: false


### PR DESCRIPTION
Remove: 
TrailingCommaInLiteral:
  Enabled: false

Add:
TrailingCommaInArrayLiteral:
  Enabled: false
TrailingCommaInHashLiteral:
  Enabled: false

Due to:
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop.yml, please update it)