### PR TITLE
Correct Metrics, revert obselete Layout names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,10 +35,7 @@
 # Sometimes beginner devs interpret line or block length restrictions as a
 # reason to make things so abbreviated as to be unreadable. These messages are
 # designed to make you write more readable code - not less.
-
-Metrics/LineLength:
-  Max: 100
-
+#
 # We want to encourage testing, but it can be verbose in the early stages.
 # So we'll give you a break. As you learn, try removing the next two sections.
 
@@ -46,6 +43,7 @@ Metrics/LineLength:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
+  Max: 100
 
 Metrics/BlockLength:
   Exclude:
@@ -286,7 +284,7 @@ FirstMethodArgumentLineBreak:
   Enabled: false
 FirstMethodParameterLineBreak:
   Enabled: false
-FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 FlipFlop:
   Enabled: false
@@ -310,11 +308,11 @@ IfWithSemicolon:
   Enabled: false
 ImplicitRuntimeError:
   Enabled: false
-IndentArray:
+IndentFirstArrayElement:
   Enabled: false
 IndentAssignment:
   Enabled: false
-IndentHash:
+IndentFirstHashElement:
   Enabled: false
 IndentHeredoc:
   Enabled: false


### PR DESCRIPTION
This PR corrects the following error:
- .rubocop.yml:39: `Metrics/LineLength` is concealed by line 45

And reverts the previous PR changes to fix the following errors:

-  Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/IndentFirstArgument`.
(obsolete configuration found in .rubocop.yml, please update it)
- The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
(obsolete configuration found in .rubocop.yml, please update it)
- The `Layout/IndentHash` cop has been renamed to `Layout/IndentFirstHashElement`.
(obsolete configuration found in .rubocop.yml, please update it)